### PR TITLE
DOCUMENTATION: Update 0.1 Purposing, Modeling & Simulation.md

### DIFF
--- a/0. Introduction/0.1 Purposing, Modeling & Simulation.md
+++ b/0. Introduction/0.1 Purposing, Modeling & Simulation.md
@@ -282,7 +282,7 @@ public class Startup
 }
 ```
 
-As you can see the code snippet above, the configuration model `Startup` offers capabilities to handle dependency injection-based registration of contracts to their concrete implementations. They may handle adding security or setting up a middleware pipeline. Configuration models are technology-specific. They may differ from a Play framework in Scala to a Spring or Flex in Paython or Java. We will outline high-level rules according to The Standard for configuration models but we will not dive deeper into the details of implementing any of it.
+As you can see the code snippet above, the configuration model `Startup` offers capabilities to handle dependency injection-based registration of contracts to their concrete implementations. They may handle adding security or setting up a middleware pipeline. Configuration models are technology-specific. They may differ from a Play framework in Scala to a Spring or Flex in Python or Java. We will outline high-level rules according to The Standard for configuration models but we will not dive deeper into the details of implementing any of it.
 
 ## 0.1.3 Simulation
 


### PR DESCRIPTION
Fix the typo from "Paython" to "Python" :)