### PR TITLE
CODERUB: Typo fix

### DIFF
--- a/1. Brokers/1.8 Broker Provider Abstraction.md
+++ b/1. Brokers/1.8 Broker Provider Abstraction.md
@@ -46,7 +46,7 @@ public class StorageBroker
 ```
 
 ## 1.8.1 Distributability
-Abstraction libraries must allow several engineers to publish their own extensions of the library. The library does not need to have implementations of all providers in one binary. Instead, these libraries must provider an interface or a contract that all other extensions need to implement to support a certain provider.
+Abstraction libraries must allow several engineers to publish their own extensions of the library. The library does not need to have implementations of all providers in one binary. Instead, these libraries must provide an interface or a contract that all other extensions need to implement to support a certain provider.
 
 For instance, Let's assume we have the core standardized contract `Standard.Storages.Core`. We may publish a library `Standard.Storages.Sql` library. Anyone else can also publish `Standard.Storages.MongoDb` to support the very same interface. An interface would look something like this:
 


### PR DESCRIPTION
Replaced "Instead, these libraries must provider an interface..." with "Instead, these libraries must provide an interface..."