### PR TITLE
CODERUB: Sentence correction

### DIFF
--- a/2. Services/2. Services.md
+++ b/2. Services/2. Services.md
@@ -86,7 +86,7 @@ For instance, a processing service should delegate the work of persisting data t
 
 For Orchestrator services, their dependencies of services (not brokers) should be limited to two or three, but not one or not four or more.
 
-If an Orchestrator depends only on one service, then violate the  definition of orchestration which is the combination of multiple operations from different sources to achieve a higher order of business logic.
+If an Orchestrator depends only on one service, then it violates the definition of orchestration which is the combination of multiple operations from different sources to achieve a higher order of business logic.
 
 ###### This pattern violates Florance Pattern
 


### PR DESCRIPTION
From: If an Orchestrator depends only on one service, then violate the definition of...
TO: If an Orchestrator depends only on one service, then it violates the definition of
