### PR TITLE
MINOR CODE RUB: Variable Naming

### DIFF
--- a/2. Services/2.1 Foundations/2.1 Foundations.md
+++ b/2. Services/2.1 Foundations/2.1 Foundations.md
@@ -1066,7 +1066,7 @@ The above model is the localization aspect of handling the issue. Now let's writ
 private async Task ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFoundAndLogItAsync()
 {
 	// given
-	Guid someStudentId = Guid.NewGuid();
+	Guid inputStudentId = Guid.NewGuid();
 	Student nullStudent = null;
 	var innerException = new Exception()
 
@@ -1082,7 +1082,7 @@ private async Task ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFound
 
 	this.storageBrokerMock.Setup(broker =>
 		broker.SelectStudentByIdAsync(inputStudentId))
-			.ReturnsAsync(noStudent);
+			.ReturnsAsync(nullStudent);
 
 	// when
 	ValueTask<Student> retrieveStudentByIdTask =

--- a/2. Services/2.1 Foundations/2.1 Foundations.md
+++ b/2. Services/2.1 Foundations/2.1 Foundations.md
@@ -1066,13 +1066,13 @@ The above model is the localization aspect of handling the issue. Now let's writ
 private async Task ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFoundAndLogItAsync()
 {
 	// given
-	Guid inputStudentId = Guid.NewGuid();
+	Guid someStudentId = Guid.NewGuid();
 	Student nullStudent = null;
 	var innerException = new Exception()
 
 	var notFoundStudentException =
 		new NotFoundStudentException(
-			message: $"Student not found with the id: {inputStudentId}",
+			message: $"Student not found with the id: {someStudentId}",
 			innerException: innerException.innerException.As<Xeption>());
 
 	var expectedStudentValidationException =
@@ -1081,12 +1081,12 @@ private async Task ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFound
 			innerException: notFoundStudentException);
 
 	this.storageBrokerMock.Setup(broker =>
-		broker.SelectStudentByIdAsync(inputStudentId))
+		broker.SelectStudentByIdAsync(someStudentId))
 			.ReturnsAsync(nullStudent);
 
 	// when
 	ValueTask<Student> retrieveStudentByIdTask =
-		this.studentService.RetrieveStudentByIdAsync(inputStudentId);
+		this.studentService.RetrieveStudentByIdAsync(someStudentId);
 
 	StudentValidationException actualStudentValidationException =
 		await Assert.ThrowsAsync<StudentValidationException>(
@@ -1097,7 +1097,7 @@ private async Task ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFound
 		expectedStudentValidationException);
 
 	this.storageBrokerMock.Verify(broker =>
-		broker.SelectStudentByIdAsync(inputStudentId),
+		broker.SelectStudentByIdAsync(someStudentId),
 			Times.Once);
 
 	this.loggingBrokerMock.Verify(broker =>


### PR DESCRIPTION
Fix variable names in ShouldThrowValidationExceptionOnRetrieveByIdIfStudentNotFoundAndLogItAsync