### PR TITLE
Update 2.1 Foundations.md: Fix AlreadyExistsStudentException

### DIFF
--- a/2. Services/2.1 Foundations/2.1 Foundations.md
+++ b/2. Services/2.1 Foundations/2.1 Foundations.md
@@ -1297,7 +1297,7 @@ For the `AlreadyExistsStudentException` the implementation would be as follows:
 We also need to bring the innerException Data property to the local exception model to ensure the original message is propagated through the system.(as previously mentioned)
 
 ```csharp
-public class AlreadyExistsStudentException : Exception
+public class AlreadyExistsStudentException : Xeption
 {
     public AlreadyExistsStudentException(
 		string message,


### PR DESCRIPTION
AlreadyExistsStudentException  should be inherited from Xeption so that can be passed to CreateAndLogDependencyValidationExceptionAsync(
	Xeption exception)